### PR TITLE
Add .npmrc and update Renovate config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
-  "extends": ["config:base"],
-  "ignorePresets": [":prHourlyLimit2", ":prConcurrentLimit20"],
+  "extends": [
+    "config:base"
+  ],
+  "ignorePresets": [
+    ":prHourlyLimit2",
+    ":prConcurrentLimit20"
+  ],
   "packageRules": [
     {
       "rangeStrategy": "bump",
@@ -12,7 +17,11 @@
       ]
     },
     {
-      "matchUpdateTypes": ["minor", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "pin",
+        "digest"
+      ],
       "automerge": true,
       "matchDepTypes": [
         "dependencies",
@@ -22,7 +31,10 @@
       ]
     },
     {
-      "matchUpdateTypes": ["patch", "lockFileMaintenance"],
+      "matchUpdateTypes": [
+        "patch",
+        "lockFileMaintenance"
+      ],
       "automerge": true,
       "automergeType": "branch",
       "matchDepTypes": [
@@ -32,5 +44,6 @@
         "peerDependencies"
       ]
     }
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
Add .npmrc with ignore-scripts=true to prevent lifecycle scripts during installs. Update renovate.json formatting and configuration: expand arrays for readability and set "minimumReleaseAge" to "3 days" to delay releases; existing automerge/package rules are preserved.